### PR TITLE
remove unused variable and fix variable type

### DIFF
--- a/js/sgp4sdp4.js
+++ b/js/sgp4sdp4.js
@@ -813,7 +813,6 @@ function Deep(ientry, sat) {
 		cc = c1ss;
 		zn = zns;
 		ze = zes;
-		zmo = sat.dps.zmos;
 		xnoi = 1.0 / sat.dps.xnq;
 
 		for (;;) {
@@ -912,7 +911,6 @@ function Deep(ientry, sat) {
 			zn = znl;
 			cc = c1l;
 			ze = zel;
-			zmo = sat.dps.zmol;
 			sat.flags |= LUNAR_TERMS_DONE_FLAG;
 		}
 
@@ -1073,7 +1071,7 @@ function Deep(ientry, sat) {
 		sat.deep_arg.omgadf = sat.deep_arg.omgadf + sat.dps.ssg
 				* sat.deep_arg.t;
 		sat.deep_arg.xnode = sat.deep_arg.xnode + sat.dps.ssh * sat.deep_arg.t;
-		sat.deep_arg.em = sat.tle.eo + sat.dps.sse * sat.deep_arg.t;
+		sat.deep_arg.em = parseFloat(sat.tle.eo) + sat.dps.sse * sat.deep_arg.t;
 		sat.deep_arg.xinc = sat.tle.xincl + sat.dps.ssi * sat.deep_arg.t;
 		if (sat.deep_arg.xinc < 0) {
 			sat.deep_arg.xinc = -sat.deep_arg.xinc;


### PR DESCRIPTION
This fixes https://gitlab.com/librespacefoundation/satnogs/satnogs-db/issues/214

There are two problems
- zmo variable is assigned but never declared. The variable is never used. Gpredict removed it also https://github.com/csete/gpredict/commit/4aae67265200506030926ef3cbba1da96aeff638?diff=unified#diff-57f38ad1d74e94573caa52b79d8e038c

- The root problem is that sat.tle.eo is passed in as a string. It is used in many places but it works because of how javascript works. In this case it didn't. The fix is a simple string->float conversion.

- I also noticed that at some point sat.deep_arg.omgadf was a string also. I didn't have time to look into where it happened and does it cause any problems further down the line.