### PR TITLE
Fix gulp and geostationary satellites

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,8 +5,8 @@ var uglify = require('gulp-uglify');
 var concat = require('gulp-concat');
 
 // Lint JS
-gulp.task('lint:js', function() {
-  return gulp.src('js/*.js')
+gulp.task('lint:js',['concat:js'], function() {
+  return gulp.src('dist/gpredict.js')
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());

--- a/js/gtk-sat-data.js
+++ b/js/gtk-sat-data.js
@@ -1,4 +1,4 @@
-
+/* exported gtk_sat_data_read_sat */
 /** \brief Read TLE data for a given satellite into memory.
  *  \param catnum The catalog number of the satellite.
  *  \param sat Pointer to a valid Sat_t structure.

--- a/js/math.js
+++ b/js/math.js
@@ -1,3 +1,4 @@
+/* exported asin */
 var sin = Math.sin;
 var cos = Math.cos;
 var sqrt = Math.sqrt;

--- a/js/math.js
+++ b/js/math.js
@@ -5,5 +5,4 @@ var floor = Math.floor;
 var pow = Math.pow;
 var fabs = Math.abs;
 var acos = Math.acos;
-var asin = Math.asin;
 var atan = Math.atan;

--- a/js/math.js
+++ b/js/math.js
@@ -5,4 +5,5 @@ var floor = Math.floor;
 var pow = Math.pow;
 var fabs = Math.abs;
 var acos = Math.acos;
+var asin = Math.asin;
 var atan = Math.atan;

--- a/js/predict-tools.js
+++ b/js/predict-tools.js
@@ -1,3 +1,4 @@
+/* exported Sat_t get_next_passes */
 /*
     Gpredict: Real-time satellite tracking and orbit prediction program
 
@@ -24,6 +25,11 @@
     You should have received a copy of the GNU General Public License
     along with this program; if not, visit http://www.fsf.org/
 */
+
+/* FIXME here are some preferences that should be fetched from somewhere else */
+const SAT_CFG_INT_PRED_RESOLUTION = 10
+const SAT_CFG_INT_PRED_NUM_ENTRIES = 10
+const SAT_CFG_INT_PRED_MIN_EL = 0
 
 /**
  * Satellite pass info default constructor.
@@ -417,7 +423,6 @@ function get_pass(sat, qth, start, maxdt, pass)
     var max_el = 0.0; /* maximum elevation */
     var detail;
     var done = false;
-    var iter = 0;      /* number of iterations */
     /* FIXME: watchdog */
 
     /* get time resolution; sat-cfg stores it in seconds */
@@ -544,7 +549,6 @@ function get_pass(sat, qth, start, maxdt, pass)
                 pass = null;
             }
 
-            iter++;
         }
     }
 

--- a/js/qth-data.js
+++ b/js/qth-data.js
@@ -1,4 +1,4 @@
-
+/* exported qth_t */
 /**
  * QTH data structure in human readable form.
  * @returns {qth_t}
@@ -8,4 +8,4 @@ function qth_t() {
      this.lat = 0.0;   /*!< Latitude in dec. deg. North. */
      this.lon = 0.0;   /*!< Longitude in dec. deg. East. */
      this.alt = 0;     /*!< Altitude above sea level in meters. */
-};
+}

--- a/js/sgp4sdp4.js
+++ b/js/sgp4sdp4.js
@@ -1,3 +1,4 @@
+/* exported isFlagSet isFlagClear ORBIT_TYPE_LEO ORBIT_TYPE_ICO ORBIT_TYPE_GSO ORBIT_TYPE_MOLNIYA ORBIT_TYPE_TUNDRA ORBIT_TYPE_POLAR ORBIT_TYPE_SUNSYNC OP_STAT_OPERATIONAL OP_STAT_NONOP OP_STAT_PARTIAL OP_STAT_STDBY OP_STAT_SPARE OP_STAT_EXTENDED */
 
 /** Type definitions **/
 
@@ -192,13 +193,10 @@ function Sat_t() {
 var de2ra    =1.74532925E-2;   /* Degrees to Radians */
 var pi       =3.1415926535898; /* Pi */
 var pio2     =1.5707963267949; /* Pi/2 */
-var x3pio2   =4.71238898;      /* 3*Pi/2 */
 var twopi    =6.2831853071796; /* 2*Pi  */
 var e6a      =1.0E-6;
 var tothrd   =6.6666667E-1;    /* 2/3 */
-var xj2      =1.0826158E-3;    /* J2 Harmonic */
 var xj3      =-2.53881E-6;      /* J3 Harmonic */   
-var xj4      =-1.65597E-6;      /* J4 Harmonic */
 var xke      =7.43669161E-2;
 var xkmper   =6.378135E3;      /* Earth radius km */
 var xmnpda   =1.44E3;          /* Minutes per day */
@@ -206,12 +204,10 @@ var ae       =1.0;
 var ck2      =5.413079E-4;
 var ck4      =6.209887E-7;
 var __f      =3.352779E-3;
-var ge       =3.986008E5; 
 var __s__    =1.012229;
 var qoms2t   =1.880279E-09;
 var secday   =8.6400E4;        /* Seconds per day */
 var omega_E  =1.0027379;
-var omega_ER =6.3003879;
 var zns      =1.19459E-5;
 var c1ss     =2.9864797E-6;
 var zes      =1.675E-2;
@@ -222,8 +218,6 @@ var zcosis   =9.1744867E-1;
 var zsinis   =3.9785416E-1;
 var zsings   =-9.8088458E-1;
 var zcosgs   =1.945905E-1;
-var zcoshs   =1;
-var zsinhs   =0;
 var q22      =1.7891679E-6;
 var q31      =2.1460748E-6;
 var q33      =2.2123015E-7;
@@ -238,10 +232,7 @@ var root44   =7.3636953E-9;
 var root52   =1.1428639E-7;
 var root54   =2.1765803E-9;
 var thdt     =4.3752691E-3;
-var rho      =1.5696615E-1;
 var mfactor  =7.292115E-5;
-var __sr__   =6.96000E5;      /*Solar radius - kilometers (IAU 76)*/
-var AU       =1.49597870E8;   /*Astronomical unit - kilometers (IAU 76)*/
 
 /* Entry points of Deep() 
 FIXME: Change to enu */
@@ -249,27 +240,17 @@ var dpinit   =1; /* Deep-space initialization code */
 var dpsec    =2; /* Deep-space secular code        */
 var dpper    =3; /* Deep-space periodic code       */
 
-/* Carriage return and line feed */
-var CR  =0x0A;
-var LF  =0x0D;
-
 /* Flow control flag definitions */
-var ALL_FLAGS              =-1;
-var SGP_INITIALIZED_FLAG   =0x000001;
 var SGP4_INITIALIZED_FLAG  =0x000002;
 var SDP4_INITIALIZED_FLAG  =0x000004;
-var SGP8_INITIALIZED_FLAG  =0x000008;
-var SDP8_INITIALIZED_FLAG  =0x000010;
 var SIMPLE_FLAG            =0x000020;
 var DEEP_SPACE_EPHEM_FLAG  =0x000040;
 var LUNAR_TERMS_DONE_FLAG  =0x000080;
-var NEW_EPHEMERIS_FLAG     =0x000100;
 var DO_LOOP_FLAG           =0x000200;
 var RESONANCE_FLAG         =0x000400;
 var SYNCHRONOUS_FLAG       =0x000800;
 var EPOCH_RESTART_FLAG     =0x001000;
 var VISIBLE_FLAG           =0x002000;
-var SAT_ECLIPSED_FLAG      =0x004000;
 
 
 /* SGP4 */

--- a/js/sgp4sdp4.js
+++ b/js/sgp4sdp4.js
@@ -813,7 +813,6 @@ function Deep(ientry, sat) {
 		cc = c1ss;
 		zn = zns;
 		ze = zes;
-		zmo = sat.dps.zmos;
 		xnoi = 1.0 / sat.dps.xnq;
 
 		for (;;) {
@@ -912,7 +911,6 @@ function Deep(ientry, sat) {
 			zn = znl;
 			cc = c1l;
 			ze = zel;
-			zmo = sat.dps.zmol;
 			sat.flags |= LUNAR_TERMS_DONE_FLAG;
 		}
 
@@ -1073,7 +1071,7 @@ function Deep(ientry, sat) {
 		sat.deep_arg.omgadf = sat.deep_arg.omgadf + sat.dps.ssg
 				* sat.deep_arg.t;
 		sat.deep_arg.xnode = sat.deep_arg.xnode + sat.dps.ssh * sat.deep_arg.t;
-		sat.deep_arg.em = sat.tle.eo + sat.dps.sse * sat.deep_arg.t;
+		sat.deep_arg.em = parseFloat(sat.tle.eo) + sat.dps.sse * sat.deep_arg.t;
 		sat.deep_arg.xinc = sat.tle.xincl + sat.dps.ssi * sat.deep_arg.t;
 		if (sat.deep_arg.xinc < 0) {
 			sat.deep_arg.xinc = -sat.deep_arg.xinc;

--- a/js/sgp_math.js
+++ b/js/sgp_math.js
@@ -1,3 +1,4 @@
+/* exported Sign Cube radians arccos Vec_Add Vec_Sub Scalar_Multiply Angle Cross Normalize
 /*
  * Unit SGP_Math
  *       Author:  Dr TS Kelso

--- a/js/sgp_obs.js
+++ b/js/sgp_obs.js
@@ -1,4 +1,4 @@
-
+/* exported Calculate_RADec_and_Obs */
 /* Procedure Calculate_User_PosVel passes the user's geodetic position */
 /* and the time of interest and returns the ECI position and velocity  */
 /* of the observer. The velocity calculation assumes the geodetic      */

--- a/js/sgp_time.js
+++ b/js/sgp_time.js
@@ -1,3 +1,4 @@
+/* exported Delta_ET Date_Time Time_of_Day Epoch_Time Calendar_Date */
 /*
  * Unit SGP_Time
  *       Author:  Dr TS Kelso
@@ -44,6 +45,8 @@ function julian_date_of_Epoch(epoch) {
 /*------------------------------------------------------------------*/
 
 /* Converts a Julian epoch to NORAD TLE epoch format */
+
+/* FIXME no idea where tm() comes from
 function Epoch_Time(jd) {
 	var yr, _time, epoch_time;
 	var edate = new tm();
@@ -58,7 +61,7 @@ function Epoch_Time(jd) {
 
 	return (epoch_time);
 }
-
+*/
 /*------------------------------------------------------------------*/
 
 /* The function DOY calculates the day of the year for the specified */


### PR DESCRIPTION
Here is a pull request which also includes fixes to make travis pass linting

Three changes to make the linting work
- change gulpfile to first combine the js files and only after that do the linting. The con of this is that gulp no longer shows which file caused errors as they all come from the dist/gpredict.js file

- add /* exported variablename */ for functions and constants that are used by progams using the lib

- remove unused variables

This also includes the fix for the satnogs-db not displaying geostationary satellites https://gitlab.com/librespacefoundation/satnogs/satnogs-db/issues/214

There are two problems

- zmo variable is assigned but never declared. The variable is never used. Gpredict removed it also csete/gpredict@4aae672?diff=unified#diff-57f38ad1d74e94573caa52b79d8e038c

- The root problem is that sat.tle.eo is passed in as a string. It is used in many places but it works because of how javascript works. In this case it didn't. The fix is a simple string->float conversion.

I also noticed that at some point sat.deep_arg.omgadf was a string also. I didn't have time to look into where it happened and does it cause any problems further down the line.
